### PR TITLE
Enable state saving for DataTables across multiple pages

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -35,11 +35,13 @@ if (isset($GLOBALS['time_start'])) {
 	});
 
 	$('.sortable').DataTable({
+        stateSave: true,
 		paging: false,
 		info: false,
 		searching: false
 	});
 	$('.sortable2').DataTable({
+        stateSave: true,
 		lengthMenu: [
 			[25, 50, 100, 200],
 			[25, 50, 100, 200]
@@ -57,6 +59,7 @@ if (isset($GLOBALS['time_start'])) {
 
 		setTimeout(function() {
 			$('.soro').DataTable({
+				stateSave: true,
 				lengthMenu: [
 					[25, 50, 100, 200],
 					[25, 50, 100, 200]

--- a/js/leadtable.js
+++ b/js/leadtable.js
@@ -6,6 +6,7 @@ function leadtable() {
         .appendTo('#leadtable tfoot');
 
     var table = $('#leadtable').DataTable({
+        // stateSave: true,
         "oLanguage": {
             "sInfo": "Showing _START_ to _END_ of _TOTAL_ items."
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - DataTables now remember their state (pagination, filtering, sorting) across page reloads for sortable tables.

- **Chores**
  - Added a note in the code regarding potential state-saving for lead tables (no user-facing changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->