### PR TITLE
Handle missing mdwiki database configuration

### DIFF
--- a/tests/MdwikiSqlDatabaseTest.php
+++ b/tests/MdwikiSqlDatabaseTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use APICalls\MdwikiSql\Database;
+use PHPUnit\Framework\TestCase;
+
+final class MdwikiSqlDatabaseTest extends TestCase
+{
+    private string $previousHome = '';
+
+    protected function setUp(): void
+    {
+        $home = getenv('HOME');
+        if ($home !== false) {
+            $this->previousHome = $home;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousHome === '') {
+            putenv('HOME');
+        } else {
+            putenv('HOME=' . $this->previousHome);
+        }
+    }
+
+    public function testMissingConfigThrowsRuntimeException(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/mdwiki_sql_test_' . uniqid();
+        mkdir($tmpDir, 0777, true);
+        putenv('HOME=' . $tmpDir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Database configuration error');
+
+        try {
+            new Database('localhost');
+        } finally {
+            $this->removeDir($tmpDir);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary
- validate the mdwiki SQL database configuration file before creating the PDO connection
- log configuration issues for operators and surface a generic runtime exception to callers
- cover the missing-configuration scenario with a PHPUnit test

## Testing
- `php -l src/backend/api_calls/mdwiki_sql.php`
- `php -l tests/MdwikiSqlDatabaseTest.php`
- `bash run_tests.sh` *(fails: vendor/bin/phpunit missing because Composer dependencies are unavailable in the environment)*


------
https://chatgpt.com/codex/tasks/task_e_69086ee9fe908322af599ef3865d5320