### PR TITLE
Ensure coordinator fallback preserves access when API is down

### DIFF
--- a/src/header.php
+++ b/src/header.php
@@ -18,9 +18,10 @@ include_once __DIR__ . '/backend/include_first/include.php';
 include_once __DIR__ . '/head.php';
 //---
 use function TD\Render\Html\banner_alert;
+use function SQLorAPI\Funcs\coordinator_active_index;
 use function SQLorAPI\Funcs\get_coordinator;
 //---
-$coordinators = array_column(get_coordinator(), 'active', 'user');
+$coordinators = coordinator_active_index(get_coordinator());
 
 $user_in_coord = false;
 if (($coordinators[$GLOBALS['global_username']] ?? 0) == 1) {

--- a/tests/CoordinatorFallbackTest.php
+++ b/tests/CoordinatorFallbackTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use function SQLorAPI\Funcs\coordinator_active_index;
+use function SQLorAPI\Funcs\normalize_coordinator_rows;
+
+final class CoordinatorFallbackTest extends TestCase
+{
+    public function testNormalizeCoordinatorRowsAddsDefaultActive(): void
+    {
+        $rows = [
+            ['user' => 'Alice'],
+            ['user' => 'Bob', 'active' => '0'],
+            ['user' => 'Carol', 'active' => 1],
+        ];
+
+        $normalized = normalize_coordinator_rows($rows);
+
+        $this->assertSame(1, $normalized[0]['active']);
+        $this->assertSame(0, $normalized[1]['active']);
+        $this->assertSame(1, $normalized[2]['active']);
+    }
+
+    public function testCoordinatorActiveIndexTreatsMissingActiveAsActive(): void
+    {
+        $rows = [
+            ['user' => 'Alice'],
+            ['user' => 'Bob', 'active' => 0],
+        ];
+
+        $index = coordinator_active_index($rows);
+
+        $this->assertSame([
+            'Alice' => 1,
+            'Bob' => 0,
+        ], $index);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize coordinator records from SQL with a default active flag to mirror the API payload
- provide a reusable coordinator index helper and rely on it in the header to treat missing active flags as enabled
- cover the new helpers with unit tests to guard the SQL fallback behaviour

## Testing
- `bash run_tests.sh` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_69086eec0c088322a0b6f5f351b28088