### PR TITLE
Handle missing database config entries

### DIFF
--- a/tests/DatabaseConfigTest.php
+++ b/tests/DatabaseConfigTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use APICalls\MdwikiSql\Database;
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+
+final class DatabaseConfigTest extends TestCase
+{
+    private ?string $originalHome = null;
+
+    protected function setUp(): void
+    {
+        $this->originalHome = getenv('HOME') !== false ? getenv('HOME') : null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalHome !== null) {
+            putenv('HOME=' . $this->originalHome);
+        } else {
+            putenv('HOME');
+        }
+    }
+
+    public function testSetDbThrowsExceptionWhenConfigMissing(): void
+    {
+        $tempHome = sys_get_temp_dir() . '/dbconfig_test_missing_' . uniqid();
+        $this->createTempHome($tempHome);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('could not be read or parsed');
+
+        try {
+            new Database('localhost');
+        } finally {
+            $this->cleanupTempHome($tempHome);
+        }
+    }
+
+    public function testSetDbThrowsExceptionWhenPasswordMissing(): void
+    {
+        $tempHome = sys_get_temp_dir() . '/dbconfig_test_incomplete_' . uniqid();
+        $this->createTempHome($tempHome, ['user' => 'exampleuser']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('password');
+
+        try {
+            new Database('tools');
+        } finally {
+            $this->cleanupTempHome($tempHome);
+        }
+    }
+
+    private function createTempHome(string $path, array $config = []): void
+    {
+        $configDir = $path . '/confs';
+        if (!is_dir($configDir)) {
+            mkdir($configDir, 0777, true);
+        }
+
+        putenv('HOME=' . $path);
+
+        if ($config !== []) {
+            $ini = '';
+            foreach ($config as $key => $value) {
+                $ini .= sprintf("%s = \"%s\"\n", $key, $value);
+            }
+            file_put_contents($configDir . '/db.ini', $ini);
+        }
+    }
+
+    private function cleanupTempHome(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                @rmdir($item->getPathname());
+            } else {
+                @unlink($item->getPathname());
+            }
+        }
+
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
## Summary
- validate parsing of the database configuration file in `Database::set_db` and throw descriptive exceptions when it is missing or incomplete
- add PHPUnit coverage that simulates absent and incomplete configuration files to exercise the new error handling

## Testing
- `./vendor/bin/phpunit tests --testdox --colors=always -c phpunit.xml` *(fails: binary not present because dev dependencies are unavailable in the environment)*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json, CONNECT tunnel failed with response 403)*

------
https://chatgpt.com/codex/tasks/task_e_69086eefb7908322b36466a05df42e5d