### PR TITLE
Migrate exists_by_qids_query from all_articles to category_members

### DIFF
--- a/src/backend/api_or_sql/new_sql_tables.php
+++ b/src/backend/api_or_sql/new_sql_tables.php
@@ -33,7 +33,7 @@ function exists_by_qids_query($lang)
     /*
         [
             { "name": "lang", "column": "t.code", "type": "text", "placeholder": "Language code", "no_mt_options": true },
-            { "name": "category", "column": "aa.category", "type": "text", "placeholder": "Category", "no_mt_options": true },
+            { "name": "category", "column": "cm.category", "type": "text", "placeholder": "Category", "no_mt_options": true },
             { "name": "campaign", "column": "campaign", "type": "text", "placeholder": "Campaign" },
             { "name": "order", "column": "order", "type": "text", "placeholder": "Order by", "no_select": true }
         ]
@@ -45,12 +45,12 @@ function exists_by_qids_query($lang)
         SELECT
             t.qid AS qid,
             q.title AS title,
-            aa.category AS category,
+            cm.category AS category,
             t.code AS code,
             t.target AS target
         FROM qids q
-            JOIN all_qids_exists t      ON t.qid = q.qid
-            LEFT JOIN all_articles aa   ON aa.article_id = q.title
+            JOIN all_qids_exists t        ON t.qid = q.qid
+            LEFT JOIN category_members cm ON cm.article_id = q.title
         WHERE t.code = ?
 
         AND (t.target != '' AND t.target IS NOT NULL)


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @MrIbrahem :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Phase 2 of the `all_articles` → `category_members` migration

Mirrors the [companion change in TD_API](https://github.com/Mdwiki-TD/TD_API). `exists_by_qids_query` here is a verbatim copy of the TD_API function, so the rewrite is identical — and brings it in line with the four neighbouring functions in the same file (`missing_by_lang_and_category`, `exists_by_lang_and_category`, `count_category_members`, `statics_by_category`), which all already query `category_members`.

### Change

`src/backend/api_or_sql/new_sql_tables.php` — `exists_by_qids_query`:

- `LEFT JOIN all_articles aa ON aa.article_id = q.title` → `LEFT JOIN category_members cm ON cm.article_id = q.title`
- `aa.category` → `cm.category` in the SELECT list and the column-hint doc-comment

### Behaviour

- **With `category=` or `campaign=` filter (when applied upstream):** identical result set.
- **Without a category/campaign filter:** an article in N categories will appear N times instead of once. This matches what every other query in this file already does against `category_members`.

### Verification

Ran locally inside the sandbox:

```
$ vendor/bin/phpstan analyse
 [OK] No errors

$ vendor/bin/phpunit
Tests: 4, Assertions: 4 — OK
```

After this PR no live code under `src/` references `all_articles`. The schema in `sql.sql` is intentionally left in place; dropping the table is Phase 4 and only happens after the TD_API and mdwiki-python-files PRs are merged and observed.

### Companion PRs

- Mdwiki-TD/TD_API — same rewrite of `exists_by_qids_query`
- Mdwiki-TD/mdwiki-python-files — Phase 1 (the three `mdcount/*.py` SELECTs and the redundant `to_sql` write) and Phase 3 (re-pointing `fix_it_db.py` at the `words` table)